### PR TITLE
fix: escape quotes as well as commas

### DIFF
--- a/base-integration/src/utilities/helper.test.ts
+++ b/base-integration/src/utilities/helper.test.ts
@@ -1,0 +1,31 @@
+import {
+  describe,
+  it,
+  expect,
+} from '@jest/globals';
+import { Helper } from './helper';
+
+describe('running-test', () => {
+  describe('csvContentChecker', () => {
+    it('should encode quotes', async () => {
+      const content = `hello "big" world`;
+      const encoded = Helper.csvContentChecker(content);
+      expect(encoded).toBe(`"hello ""big"" world"`);
+    });
+    it('should encode commas', async () => {
+      const content = `hello, or not`;
+      const encoded = Helper.csvContentChecker(content);
+      expect(encoded).toBe(`"hello, or not"`);
+    });
+    it('should encode both quotes and commas', async () => {
+      const content = `h "and," or something else, or "not"`;
+      const encoded = Helper.csvContentChecker(content);
+      expect(encoded).toBe(`"h ""and,"" or something else, or ""not"""`);
+    });
+    it('should return normal text', async () => {
+      const content = `hello world`;
+      const encoded = Helper.csvContentChecker(content);
+      expect(encoded).toBe(`hello world`);
+    });
+  })
+})

--- a/base-integration/src/utilities/helper.ts
+++ b/base-integration/src/utilities/helper.ts
@@ -1,15 +1,19 @@
 export class Helper {
-    static csvContentChecker(data:string) : string {
-        if (data == null) {
-            return '';
-        }
-
-        var finalData = data.trim()
-
-        if (finalData.indexOf(',') != -1) {
-            return `"${finalData}"`;
-        }
-
-        return finalData
+  static csvContentChecker(data:string) : string {
+    if (data == null) {
+      return '';
     }
+
+    let finalData = data.trim();
+
+    if (
+      finalData.indexOf(',') < 0
+      && finalData.indexOf('"') < 0
+    ) {
+      return finalData;
+    }
+
+    finalData = finalData.replace(/"/g, '""');
+    return `"${finalData}"`;
+  }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    testEnvironment: 'node',
+    testMatch: ['**/*.test.ts'],
+    transform: {
+      '^.+\\.(ts|tsx)?$': 'ts-jest'
+    }
+};


### PR DESCRIPTION
[ab#163369](https://dev.azure.com/kpaonline/KPA%20Flex/_workitems/edit/163369)

Correctly encode CSV content containing quotes.

## Testing

```bash
npx jest helper.test.ts
```